### PR TITLE
Add Proxy & viewDistance config

### DIFF
--- a/common/src/main/java/org/teacon/slides/SlideshowClient.java
+++ b/common/src/main/java/org/teacon/slides/SlideshowClient.java
@@ -2,6 +2,7 @@ package org.teacon.slides;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
+import org.teacon.slides.config.Config;
 import org.teacon.slides.projector.ProjectorScreen;
 import org.teacon.slides.renderer.ProjectorRenderer;
 import org.teacon.slides.renderer.SlideState;
@@ -14,5 +15,6 @@ public class SlideshowClient {
 		RegistryClient.registerTickEvent(SlideState::tick);
 		RegistryClient.registerClientStoppingEvent(SlideState::onPlayerLeft);
 		RegistryClient.registerNetworkReceiver(Slideshow.PACKET_OPEN_GUI, packet -> ProjectorScreen.openScreen(Minecraft.getInstance(), packet));
+		Config.refreshProperties();
 	}
 }

--- a/common/src/main/java/org/teacon/slides/cache/ImageCache.java
+++ b/common/src/main/java/org/teacon/slides/cache/ImageCache.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.teacon.slides.Slideshow;
+import org.teacon.slides.config.Config;
 
 import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
@@ -66,7 +67,11 @@ public final class ImageCache {
 			throw new RuntimeException("Failed to create cache directory for slide images.", e);
 		}
 		mCacheStorage = new CacheStorage(dir);
-		mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).build();
+		if (Config.isProxySwitch()) {
+			mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).setProxy(Config.PROXY).build();
+		} else {
+			mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).build();
+		}
 	}
 
 	@Nonnull

--- a/common/src/main/java/org/teacon/slides/cache/SlideImageStore.java
+++ b/common/src/main/java/org/teacon/slides/cache/SlideImageStore.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.teacon.slides.Slideshow;
+import org.teacon.slides.config.Config;
 
 import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
@@ -71,7 +72,11 @@ public final class SlideImageStore {
 			throw new RuntimeException("Failed to create cache directory for slide images.", e);
 		}
 		mCacheStorage = new CacheStorage(dir);
-		mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).build();
+		if(Config.isProxySwitch()){
+			mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).setProxy(Config.PROXY).build();
+		} else {
+			mHttpClient = CachingHttpClients.custom().setCacheConfig(CONFIG).setHttpCacheStorage(mCacheStorage).build();
+		}
 	}
 
 	@Nonnull

--- a/common/src/main/java/org/teacon/slides/config/Config.java
+++ b/common/src/main/java/org/teacon/slides/config/Config.java
@@ -19,15 +19,22 @@ public class Config {
     private static boolean proxySwitch = false;
     private static String host = "127.0.0.1";
     private static int port = 8080;
+    private static double viewDistance = 128.0;
     public static HttpHost PROXY;
 
     private static final String PROXY_SWITCH = "proxySwitch";
     private static final String HOST = "host";
     private static final String PORT = "port";
+    private static final String VIEW_DISTANCE = "slideshowViewDistance";
+
     private static final Path CONFIG_PATH = Minecraft.getInstance().gameDirectory.toPath().resolve("config").resolve("slideshow.json");
 
     public static boolean isProxySwitch() {
         return proxySwitch;
+    }
+
+    public static double getViewDistance() {
+        return viewDistance;
     }
 
     public static void refreshProperties() {
@@ -44,6 +51,10 @@ public class Config {
             }
             try {
                 port = jsonConfig.get(PORT).getAsInt();
+            } catch (Exception ignored) {
+            }
+            try {
+                viewDistance = jsonConfig.get(VIEW_DISTANCE).getAsDouble();
             } catch (Exception ignored) {
             }
             if (proxySwitch) {
@@ -66,8 +77,9 @@ public class Config {
         jsonConfig.addProperty(PROXY_SWITCH, proxySwitch);
         jsonConfig.addProperty(HOST, host);
         jsonConfig.addProperty(PORT, port);
+        jsonConfig.addProperty(VIEW_DISTANCE, viewDistance);
         try {
-            if(!Files.exists(CONFIG_PATH.getParent())){
+            if (!Files.exists(CONFIG_PATH.getParent())) {
                 Files.createDirectories(CONFIG_PATH.getParent());
             }
             Files.write(CONFIG_PATH, Collections.singleton(prettyPrint(jsonConfig)));

--- a/common/src/main/java/org/teacon/slides/config/Config.java
+++ b/common/src/main/java/org/teacon/slides/config/Config.java
@@ -1,0 +1,83 @@
+package org.teacon.slides.config;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.minecraft.client.Minecraft;
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class Config {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static boolean proxySwitch = false;
+    private static String host = "127.0.0.1";
+    private static int port = 8080;
+    public static HttpHost PROXY;
+
+    private static final String PROXY_SWITCH = "proxySwitch";
+    private static final String HOST = "host";
+    private static final String PORT = "port";
+    private static final Path CONFIG_PATH = Minecraft.getInstance().gameDirectory.toPath().resolve("config").resolve("slideshow.json");
+
+    public static boolean isProxySwitch() {
+        return proxySwitch;
+    }
+
+    public static void refreshProperties() {
+        LOGGER.info("Refreshed Slideshow mod config");
+        try {
+            final JsonObject jsonConfig = new JsonParser().parse(String.join("", Files.readAllLines(CONFIG_PATH))).getAsJsonObject();
+            try {
+                proxySwitch = jsonConfig.get(PROXY_SWITCH).getAsBoolean();
+            } catch (Exception ignored) {
+            }
+            try {
+                host = jsonConfig.get(HOST).getAsString();
+            } catch (Exception ignored) {
+            }
+            try {
+                port = jsonConfig.get(PORT).getAsInt();
+            } catch (Exception ignored) {
+            }
+            if (proxySwitch) {
+                PROXY = new HttpHost(host, port);
+                LOGGER.info("Proxy loaded");
+                LOGGER.info(HOST + ": " + host);
+                LOGGER.info(PORT + ": " + port);
+            } else {
+                PROXY = null;
+            }
+        } catch (Exception e) {
+            writeToFile();
+            refreshProperties();
+        }
+    }
+
+    private static void writeToFile() {
+        LOGGER.info("Wrote Slideshow mod config to file");
+        final JsonObject jsonConfig = new JsonObject();
+        jsonConfig.addProperty(PROXY_SWITCH, proxySwitch);
+        jsonConfig.addProperty(HOST, host);
+        jsonConfig.addProperty(PORT, port);
+        try {
+            if(!Files.exists(CONFIG_PATH.getParent())){
+                Files.createDirectories(CONFIG_PATH.getParent());
+            }
+            Files.write(CONFIG_PATH, Collections.singleton(prettyPrint(jsonConfig)));
+        } catch (IOException e) {
+            LOGGER.error("Configuration file write exception");
+            e.printStackTrace();
+        }
+    }
+
+    private static String prettyPrint(JsonElement jsonElement) {
+        return new GsonBuilder().setPrettyPrinting().create().toJson(jsonElement);
+    }
+}

--- a/common/src/main/java/org/teacon/slides/projector/ProjectorBlockEntity.java
+++ b/common/src/main/java/org/teacon/slides/projector/ProjectorBlockEntity.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.state.BlockState;
 import org.teacon.slides.Registries;
+import org.teacon.slides.config.Config;
 import org.teacon.slides.mappings.BlockEntityClientSerializableMapper;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -20,6 +21,7 @@ public final class ProjectorBlockEntity extends BlockEntityClientSerializableMap
 	public float mOffsetY = 0;
 	public float mOffsetZ = 0;
 	public boolean mDoubleSided = true;
+	private static final double VIEW_DISTANCE = Config.getViewDistance();
 
 	public ProjectorBlockEntity(BlockPos blockPos, BlockState blockState) {
 		super(Registries.BLOCK_ENTITY.get(), blockPos, blockState);
@@ -49,5 +51,10 @@ public final class ProjectorBlockEntity extends BlockEntityClientSerializableMap
 		mOffsetY = compoundTag.getFloat("OffsetY");
 		mOffsetZ = compoundTag.getFloat("OffsetZ");
 		mDoubleSided = compoundTag.getBoolean("DoubleSided");
+	}
+
+	@Override
+	public double getViewDistance(){
+		return VIEW_DISTANCE;
 	}
 }

--- a/forge/src/main/java/org/teacon/slides/SlideshowForge.java
+++ b/forge/src/main/java/org/teacon/slides/SlideshowForge.java
@@ -39,7 +39,7 @@ public class SlideshowForge {
 		eventBus.register(SlideshowModEventBus.class);
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
 			MinecraftForge.EVENT_BUS.register(ForgeUtilities.Events.class);
-			eventBus.register(ForgeUtilities.RegisterEntityRenderer.class);
+			eventBus.register(ForgeUtilities.ClientsideEvents.class);
 		});
 	}
 


### PR DESCRIPTION
1.The proxy function is added. When the user uses Slideshow for the first time, slideshow.json will be created in the config folder. In slideshow.json, whether to enable the Http proxy and the address and port of the proxy can be controlled.
Purpose: When users in mainland China use Slideshow, if the picture cannot be loaded, you can try to set a proxy
2.Update parts of Forge code to use new Minecraft Mappings
3.The viewing distance of the projector can be modified in the configuration file, and it can be seen from farther away